### PR TITLE
[WIP] update to extract-matches.py instead of samtools faidx

### DIFF
--- a/extract-matches.py
+++ b/extract-matches.py
@@ -1,0 +1,21 @@
+#! /usr/bin/env python
+# by C. Titus Brown
+
+import argparse, screed, sys
+
+parser = argparse.ArgumentParser()
+parser.add_argument('names')
+parser.add_argument('seqfile')
+args = parser.parse_args()
+
+names = set([ x.strip() for x in open(args.names) ])
+found = set()
+
+for record in screed.open(args.seqfile):
+    shortname = record.name.split()[0]
+    if shortname in names:
+        print('>{}\n{}'.format(record.name, record.sequence))
+        found.add(shortname)
+
+
+sys.stderr.write('found {} of {} ({} missing)\n'.format(len(found), len(names), len(names - found)))


### PR DESCRIPTION
removes samtools extraction, makes single file for BLAST instead of dynamic output. 

note, post-processing scripts will have to updated to read in one BLAST file instead of multiple, and the Snakefile may need to be updated so it has a single output instead of a dynamic output for BLAST. 